### PR TITLE
Fix merge, add device dependent handling of Wifi, improve Frontlight toggle feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ bookeenupdate: all
 	# remove old package if any
 	rm -f $(BOOKEEN_PACKAGE)
 	# Bookeen scripts
-	cp $(REMARKABLE_DIR)/* $(INSTALL_DIR)/koreader
+	cp $(BOOKEEN_DIR)/* $(INSTALL_DIR)/koreader
 	cp $(COMMON_DIR)/spinning_zsync $(INSTALL_DIR)/koreader
 	# create new package
 	cd $(INSTALL_DIR) && \
@@ -465,7 +465,7 @@ bookeenupdate: all
 	        koreader/ota/package.index
 	# make gzip bookeen update for zsync OTA update
 	cd $(INSTALL_DIR) && \
-	        tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(BOOKEEN_PACKAGE) \
+	        tar -I"gzip --rsyncable" -cah --no-recursion -f ../$(BOOKEEN_PACKAGE_OTA) \
 	        -T koreader/ota/package.index
 
 
@@ -549,7 +549,7 @@ else ifeq ($(TARGET), sony-prstux)
 else ifeq ($(TARGET), remarkable)
 	make remarkableupdate
 else ifeq ($(TARGET), bookeen)
-	make remarkableupdate
+	make bookeenupdate
 
 else ifeq ($(TARGET), ubuntu-touch)
 	make utupdate

--- a/platform/bookeen/wlan.sh
+++ b/platform/bookeen/wlan.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+IFACE=wlan0
+WLAN_MODULE=/lib/modules/3.0.8+/8188eu.ko
+IFCONFIG=/sbin/ifconfig
+INSMOD=/sbin/insmod
+LSMOD=/sbin/lsmod
+RMMOD=/sbin/rmmod
+
+start ()
+{
+	echo "Loading WLAN driver"
+
+	#check if wlan driver is already up
+	wlan_if=`$IFCONFIG | grep $IFACE`
+
+	if [ -n "$wlan_if" ]; then
+		#WLAN interface already up
+		return 0
+	fi
+
+	if [ ! -f $WLAN_MODULE ]; then
+		return -1
+	fi
+
+	/sbin/nvram
+	if [ $? -ne 0 ]; then
+		echo "Error : nvram is in read only. Using default MAC address : 90:D7:4F:42:42:42"
+		MAC_ADDR="90:D7:4F:42:42:42"
+	else
+		MAC_ADDR=`/sbin/nvram -e | cut -d '=' -f2`
+	fi
+
+	$INSMOD $WLAN_MODULE rtw_initmac=$MAC_ADDR
+
+	sleep 1
+
+	wlan_loaded=`$LSMOD | grep 8188eu`
+
+	if [ -n "$wlan_loaded" ]; then
+		$IFCONFIG $IFACE up
+	else
+		return -2
+	fi
+	
+	wpa_supplicant -B -i wlan0 -c /mnt/fat/system/bin/ws.conf
+
+	return 0
+}
+
+suspend()
+{
+	power s 8188eu
+}
+
+resume()
+{
+	power 1 8188eu
+}
+
+stop ()
+{
+	echo "Unloading WLAN driver"
+	wlan_loaded=`$LSMOD | grep 8188eu`
+
+	if [ -n "$wlan_loaded" ]; then
+		wpa_cli terminate
+		$IFCONFIG $IFACE down
+		$RMMOD 8188eu
+		return 0
+	else
+		return -1
+	fi
+}
+
+restart ()
+{
+	stop
+	start
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	suspend)
+		suspend
+		;;
+	resume)
+		resume
+		;;
+	restart)
+		restart
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+esac
+
+exit 0
+

--- a/platform/bookeen/wlan.sh
+++ b/platform/bookeen/wlan.sh
@@ -42,8 +42,8 @@ start ()
 	else
 		return -2
 	fi
-	
-	wpa_supplicant -B -i wlan0 -c /mnt/fat/system/bin/ws.conf
+
+	wpa_supplicant -B -i wlan0 -C /var/run/wpa_supplicant
 
 	return 0
 }


### PR DESCRIPTION
Hello @rstar000 ,
I believe that the conflicts where wrongly resolved: it merge your new wifi changes with the old behavior.
This PR fixes that :)

== Wifi

To advance in Wifi handling, I also cherry picked https://github.com/rstar000/koreader/commit/68c5d66f0a9bd40bd50a0117a0a38b757a65a627 and needed to make the following modification :
`wpa_supplicant -B -i wlan0 -c /mnt/fat/system/bin/ws.conf` -> `wpa_supplicant -B -i wlan0 -C /var/run/wpa_supplicant`
This create the `/var/run/wpa_supplicant/wlan0` socket when `wpa_supplicant` is launched.
This is the expected socket in your code so it should not break anything on your side.

I do not have `dhcpcd` on my device, so I also fixed that for obtaining/releasing IP address.

== Frontlight

I improved a bit the Frontlight toggling (Now when Frontlight was off and toggled to on, I check if the intensity is `0`. If so I set it to `1`. It avoid to think _"Uh? Does not work?"_ while the Frontlight is on and with an intensity of `0` :D

== Misc

I also fixed the `kodev release bookeen` step.
I use the bookeen Toolchain via `docker run -v $(pwd)/koreader:/home/ko/koreader -v $(pwd)/koreader-base:/home/ko/koreader-base -it koreader/kobookeen:0.1.0 /bin/bash` and usually run my build from the `koreader` folder with `KOR_BASE=../koreader-base/ TARGET=bookeen KODEBUG=1 ./kodev release bookeen`.

As such, I only have one fix for you to integrate in `koreader-base` :)

```diff
diff --git a/Makefile.defs b/Makefile.defs
index 6ca42b2..9d82b90 100644
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -167,7 +167,7 @@ else ifeq ($(TARGET), cervantes)
        endif
        export USE_LJ_WPACLIENT=1
 else ifeq ($(TARGET), bookeen)
-       CHOST?=arm-pocketbook-linux-gnueabi
+       CHOST?=arm-bookeen-linux-gnueabi
        export BOOKEEN=1
        HAS_POCKETBOOK_TC:=$(shell command -v arm-pocketbook-linux-gnueabi-gcc 2> /dev/null)
        ifdef HAS_POCKETBOOK_TC
```
Kind regards,
/Lenain